### PR TITLE
Clarify `WRANGLER_LOG` variable behaviour

### DIFF
--- a/content/workers/wrangler/system-environment-variables.md
+++ b/content/workers/wrangler/system-environment-variables.md
@@ -46,7 +46,7 @@ Wrangler supports the following environment variables:
 
 - `WRANGLER_LOG` {{<type>}}string{{</type>}} {{<prop-meta>}}optional{{</prop-meta>}}
 
-  - Options for Logging levels are `"none"`, `"error"`, `"warn"`, `"info"`, `"log"` and `"debug"`.
+  - Options for Logging levels are `"none"`, `"error"`, `"warn"`, `"info"`, `"log"` and `"debug"`. Levels are case-insensitive and default to `"log"`. If an invalid level is specified, Wrangler will fallback to the default.
 
 {{</definitions>}}
 


### PR DESCRIPTION
[emiratesnbd.net](http://emiratesnbd.net/)نظرة عامة على نطاق [emiratesnbd.net](http://emiratesnbd.net/) في Whois
Domain Name: [EMIRATESNBD.NET](http://emiratesnbd.net/)
Registry Domain ID: 1525114799_DOMAIN_NET-VRSN
Registrar WHOIS Server: [whois.nic.ae](http://whois.nic.ae/)
Registrar URL: http://www.nic.ae/
Updated Date: 2018-11-19T07:55:59Z
Creation Date: 2008-10-21T05:22:01Z
Registry Expiry Date: 2023-10-21T05:22:01Z
Registrar: Emirates Telecommunications Corporation - Etisalat
Registrar IANA ID: 1738
Registrar Abuse Contact Email: [abuse@nic.ae](mailto:abuse@nic.ae)
Registrar Abuse Contact Phone: [+971.43717272](tel:+97143717272)
Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
Name Server: [A1.VERISIGNDNS.COM](http://a1.verisigndns.com/)
Name Server: [A2.VERISIGNDNS.COM](http://a2.verisigndns.com/)
Name Server: [A3.VERISIGNDNS.COM](http://a3.verisigndns.com/)
DNSSEC: unsigned
URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
>>> Last update of whois database: 2023-08-08T07:56:00Z <<<

For more information on Whois status codes, please visit https://icann.org/epp

NOTICE: The expiration date displayed in this record is the date the
registrar's sponsorship of the domain name registration in the registry is
currently set to expire. This date does not necessarily reflect the expiration
date of the domain name registrant's agreement with the sponsoring
registrar. Users may consult the sponsoring registrar's Whois database to
view the registrar's reported date of expiration for this registration.

TERMS OF USE: You are not authorized to access or query our Whois
database through the use of electronic processes that are high-volume and
automated except as reasonably necessary to register domain names or
modify existing registrations; the Data in VeriSign Global Registry
Services' ("VeriSign") Whois database is provided by VeriSign for
information purposes only, and to assist persons in obtaining information
about or related to a domain name registration record. VeriSign does not
guarantee its accuracy. By submitting a Whois query, you agree to abide
by the following terms of use: You agree that you may use this Data only
for lawful purposes and that under no circumstances will you use this Data
to: (1) allow, enable, or otherwise support the transmission of mass
unsolicited, commercial advertising or solicitations via e-mail, telephone,
or facsimile; or (2) enable high volume, automated, electronic processes
that apply to VeriSign (or its computer systems). The compilation,
repackaging, dissemination or other use of this Data is expressly
prohibited without the prior written consent of VeriSign. You agree not to
use electronic processes that are automated and high-volume to access or
query the Whois database except as reasonably necessary to register
domain names or modify existing registrations. VeriSign reserves the right
to restrict your access to the Whois database in its sole discretion to ensure
operational stability. VeriSign may restrict or terminate your access to the
Whois database for failure to abide by these terms of use. VeriSign
reserves the right to modify these terms at any time.

The Registry database contains ONLY .COM, .NET, .EDU domains and
Registrars.
الخصوصية
البنود
Impressum
Verträge kündigen
"

احصل على [Outlook for Android](https://aka.ms/AAb9ysg)